### PR TITLE
Correção de valor na chamada da API e refatoração

### DIFF
--- a/js/formulario.mjs
+++ b/js/formulario.mjs
@@ -46,27 +46,13 @@ function validaForm(formulario){
 }
 
 function montaForm(formulario){
-    let data = {};
-    for (let i = 0; i < formulario.length; ++i) {
-        let input = formulario[i];
-
-        if(!isNaN(input.value) && input.value) {
-            data[input.name] = parseInt(input.value);                     
-        }                            
-        else {
-            data[input.name] = input.value;
-        } 
-    }
+    let data = [...new FormData(formulario)].reduce((acumulador, campoValor) => {
+        acumulador[campoValor[0]] = campoValor[1];
+        return acumulador;
+    }, {});
 
     document.querySelectorAll('seletor-pontos').forEach(function(seletorDePontos){
-        let qntdDePontos = 0;
-        
-        seletorDePontos.shadowRoot.querySelectorAll('input[type="checkbox"]').forEach(function(ponto){
-            if (ponto.checked)
-                qntdDePontos++;
-        });
-
-        data[seletorDePontos.getAttribute('atributo')] = qntdDePontos;
+        data[seletorDePontos.getAttribute('atributo')] = seletorDePontos.shadowRoot.querySelectorAll('input[type="checkbox"]:checked').length;
     });
 
     return data;

--- a/js/formulario.mjs
+++ b/js/formulario.mjs
@@ -46,12 +46,11 @@ function validaForm(formulario){
 }
 
 function montaForm(formulario){
-    let data = [...new FormData(formulario)].reduce((acumulador, campoValor) => {
-        acumulador[campoValor[0]] = campoValor[1];
-        return acumulador;
-    }, {});
+    let data = {};
+    
+    [...new FormData(formulario)].forEach(([campo, valor]) => data[campo] = valor);
 
-    document.querySelectorAll('seletor-pontos').forEach(function(seletorDePontos){
+    document.querySelectorAll('seletor-pontos').forEach(seletorDePontos => {
         data[seletorDePontos.getAttribute('atributo')] = seletorDePontos.shadowRoot.querySelectorAll('input[type="checkbox"]:checked').length;
     });
 
@@ -105,10 +104,8 @@ export function prepararLimpezaDoFormulario(formulario, botaoEnviaFormulario) {
     
         formulario.reset();
     
-        for (let i = 0; i < formulario.length; ++i) {
-            formulario[i].classList.remove("pontuacaoInvalida");
-        }
-    
+        [...formulario].forEach(elemento => elemento.classList.remove("pontuacaoInvalida"));
+
         reiniciarComponentesDePontos(); 
     
         placarPontosDisponiveis.reiniciarPontuacao();


### PR DESCRIPTION
O JSON enviado para a API estava indo com um par vazio (`{"": ""}`) porque o `for` percorria elementos que não deveria, como botões. A classe `FormData` (nativa) já filtra esses campos.

A contagem de pontos, embora ligeiramente refatorada, ainda não considera pontos extras. Já estava assim antes deste commit.

Eu entendo que o `seletor-pontos` deveria encapsular a contagem dos seus pontos e retorná-los através de uma propriedade `pontos` - que já existe, porém está retornando sempre zero.